### PR TITLE
Add rule to ignore temporary vim files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore temporary vim files
+*.swp


### PR DESCRIPTION
This rule is intended to prevent me from adding temporary files to the git repository by mistake.
